### PR TITLE
Fix type mismatch for linux

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -71,7 +71,13 @@ pub fn start<T>(daemon: ForgeDaemon<T>) -> DaemonResult<T> {
                     io::Error::last_os_error()
                 )));
             }
+            #[cfg(target_os = "macos")]
             if libc::chdir(b"/\0".as_ptr() as *const i8) < 0 {
+                return Err(DaemonError::Io(io::Error::last_os_error()));
+            }
+            
+            #[cfg(target_os = "linux")]
+            if libc::chdir(b"/\0".as_ptr() as *const u8) < 0 {
                 return Err(DaemonError::Io(io::Error::last_os_error()));
             }
         }

--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -71,13 +71,13 @@ pub fn start<T>(daemon: ForgeDaemon<T>) -> DaemonResult<T> {
                     io::Error::last_os_error()
                 )));
             }
-            #[cfg(target_os = "macos")]
-            if libc::chdir(b"/\0".as_ptr() as *const i8) < 0 {
-                return Err(DaemonError::Io(io::Error::last_os_error()));
-            }
+            #[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
+            type CChar = i8;
             
-            #[cfg(target_os = "linux")]
-            if libc::chdir(b"/\0".as_ptr() as *const u8) < 0 {
+            #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+            type CChar = u8;
+            
+            if libc::chdir(b"/\0".as_ptr() as *const CChar) < 0 {
                 return Err(DaemonError::Io(io::Error::last_os_error()));
             }
         }


### PR DESCRIPTION
Description

On aarch64 Ubuntu, I’m encountering a Rust compiler error: libc::chdir expects a *const u8, but the pointer is inferred as *const i8. This issue doesn’t occur on macOS, where the code compiles and runs correctly.
Error message

```sh
error[E0308]: mismatched types
  |
74 |             if libc::chdir(b"/\0".as_ptr() as *const i8) < 0 {
  |                ----------- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected `*const u8`, found `*const i8`
  |                |
  |                arguments to this function are incorrect
  |
  = note: expected raw pointer `*const u8`
             found raw pointer `*const i8`
```

Code snippet

File: src/sys/unix.rs

```sh
if libc::chdir(b"/\0".as_ptr() as *const i8) < 0 {
    return Err(DaemonError::Io(io::Error::last_os_error()));
}
```

Fix

```rust
#[cfg(not(all(target_os = "linux", target_arch = "aarch64")))]
type CChar = i8;

#[cfg(all(target_os = "linux", target_arch = "aarch64"))]
type CChar = u8;

if libc::chdir(b"/\0".as_ptr() as *const CChar) < 0 {
    return Err(DaemonError::Io(io::Error::last_os_error()));
}
```